### PR TITLE
Add custom description to the main CoreBluetooth wrappers

### DIFF
--- a/Source/Characteristic.swift
+++ b/Source/Characteristic.swift
@@ -179,6 +179,12 @@ public class Characteristic {
     }
 }
 
+extension Characteristic: CustomStringConvertible {
+    public var description: String {
+        return "\(type(of: self)) \(uuid)"
+    }
+}
+
 extension Characteristic: Equatable {}
 extension Characteristic: UUIDIdentifiable {}
 

--- a/Source/Descriptor.swift
+++ b/Source/Descriptor.swift
@@ -106,6 +106,12 @@ public class Descriptor {
     }
 }
 
+extension Descriptor: CustomStringConvertible {
+    public var description: String {
+        return "\(type(of: self)) \(uuid)"
+    }
+}
+
 extension Descriptor: Equatable {}
 
 /// Compare two descriptors. Descriptors are the same when their UUIDs are the same.

--- a/Source/Peripheral.swift
+++ b/Source/Peripheral.swift
@@ -872,6 +872,12 @@ public class Peripheral {
     }
 }
 
+extension Peripheral: CustomStringConvertible {
+    public var description: String {
+        return "\(type(of: self)) \(peripheral.name ?? "nil") (\(peripheral.identifier))"
+    }
+}
+
 extension Peripheral: Equatable {}
 
 /// Compare two peripherals which are the same when theirs identifiers are equal.

--- a/Source/Service.swift
+++ b/Source/Service.swift
@@ -80,6 +80,12 @@ public class Service {
     }
 }
 
+extension Service: CustomStringConvertible {
+    public var description: String {
+        return "\(type(of: self)) \(uuid)"
+    }
+}
+
 extension Service: Equatable {}
 extension Service: UUIDIdentifiable {}
 

--- a/Tests/Autogenerated/_CentralManager.generated.swift
+++ b/Tests/Autogenerated/_CentralManager.generated.swift
@@ -303,13 +303,13 @@ class _CentralManager: _ManagerType {
                 return (peripheral, error)
             }
         return ensure(.poweredOn, observable: observable)
-                .catch { error in
-                    if error is _BluetoothError, let peripheral = peripheral {
-                        return .concat(.just((peripheral, error)), .error(error))
-                    } else {
-                        return .error(error)
-                    }
+            .catch { error in
+                if error is _BluetoothError, let peripheral = peripheral {
+                    return .concat(.just((peripheral, error)), .error(error))
+                } else {
+                    return .error(error)
                 }
+            }
     }
 
     // MARK: ANCS

--- a/Tests/Autogenerated/_Characteristic.generated.swift
+++ b/Tests/Autogenerated/_Characteristic.generated.swift
@@ -180,6 +180,12 @@ class _Characteristic {
     }
 }
 
+extension _Characteristic: CustomStringConvertible {
+    var description: String {
+        return "\(type(of: self)) \(uuid)"
+    }
+}
+
 extension _Characteristic: Equatable {}
 extension _Characteristic: UUIDIdentifiable {}
 

--- a/Tests/Autogenerated/_Descriptor.generated.swift
+++ b/Tests/Autogenerated/_Descriptor.generated.swift
@@ -107,6 +107,12 @@ class _Descriptor {
     }
 }
 
+extension _Descriptor: CustomStringConvertible {
+    var description: String {
+        return "\(type(of: self)) \(uuid)"
+    }
+}
+
 extension _Descriptor: Equatable {}
 
 /// Compare two descriptors. Descriptors are the same when their UUIDs are the same.

--- a/Tests/Autogenerated/_Peripheral.generated.swift
+++ b/Tests/Autogenerated/_Peripheral.generated.swift
@@ -873,6 +873,12 @@ class _Peripheral {
     }
 }
 
+extension _Peripheral: CustomStringConvertible {
+    var description: String {
+        return "\(type(of: self)) \(peripheral.name ?? "nil") (\(peripheral.identifier))"
+    }
+}
+
 extension _Peripheral: Equatable {}
 
 /// Compare two peripherals which are the same when theirs identifiers are equal.

--- a/Tests/Autogenerated/_Service.generated.swift
+++ b/Tests/Autogenerated/_Service.generated.swift
@@ -81,6 +81,12 @@ class _Service {
     }
 }
 
+extension _Service: CustomStringConvertible {
+    var description: String {
+        return "\(type(of: self)) \(uuid)"
+    }
+}
+
 extension _Service: Equatable {}
 extension _Service: UUIDIdentifiable {}
 


### PR DESCRIPTION
Logging an RxBluetoothKit.Service is not helpful at all, since the description looks like this: "RxBluetoothKit.Service". Add custom description to the main CoreBluetooth wrappers: Peripheral, Service, Characteristic, Descriptor.